### PR TITLE
Fix exception on null body.

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ function *genFeed() {
 				categories: issue.labels.map(label => label.name),
 				author: issue.user.login,
 				date: issue.created_at,
-				description: marked(issue.body)
+				description: marked(issue.body || '')
 			})
 		})
 


### PR DESCRIPTION
I'm not sure what changed, but my feed stopped working because it was crashing
due to an issue without a body.  The body is null and `marked` was failing
with this error:

```
  Error: marked(): input parameter is undefined or null
      at marked (/gh-feed/node_modules/marked/lib/marked.js:1244:11)
      at JSON.parse.slice.forEach.issue (/gh-feed/index.js:155:18)
      at Array.forEach (<anonymous>)
      at Object.genFeed (/gh-feed/index.js:148:4)
      at genFeed.next (<anonymous>)
      at Object.dispatch (/gh-feed/node_modules/koa-router/lib/router.js:334:5)
      at dispatch.next (<anonymous>)
      at Object.compress (/gh-feed/node_modules/koa-compress/index.js:42:5)
      at compress.next (<anonymous>)
      at Object.<anonymous> (/gh-feed/node_modules/koa-compose/index.js:28:5)
```